### PR TITLE
Support for Anthem MLX SLM

### DIFF
--- a/src/AnthemController.ts
+++ b/src/AnthemController.ts
@@ -928,7 +928,6 @@ export class AnthemController extends TypedEmitter<AnthemControllerEvent> {
     // Get Zone power status
     //
     GetZonePower(ZoneNumber: number){
-      this.emit('ShowDebugInfo', 'Zone number: '+ZoneNumber);
       return this.Zones[ZoneNumber].GetIsPowered();
     }
 

--- a/src/AnthemController.ts
+++ b/src/AnthemController.ts
@@ -928,6 +928,7 @@ export class AnthemController extends TypedEmitter<AnthemControllerEvent> {
     // Get Zone power status
     //
     GetZonePower(ZoneNumber: number){
+      this.emit('ShowDebugInfo', 'Zone number: '+ZoneNumber);
       return this.Zones[ZoneNumber].GetIsPowered();
     }
 

--- a/src/AnthemController.ts
+++ b/src/AnthemController.ts
@@ -33,7 +33,7 @@ export enum AnthemReceiverModel {
   AVM90 = 'AVM 90'
 }
 
-export enum AnthemAudioListenningMode {
+export enum AnthemAudioListeningMode {
   NONE = 0,
   ANTHEMLOGIC_CINEMA = 1,
   ANTHEMLOGIC_MUSIC = 2,
@@ -144,7 +144,7 @@ export enum AnthemKeyCode {
   }
 
 export class AnthemZone{
-  ZoneNumber = 1;
+  ZoneNumber = 0;
   private IsMainZone = false;
   private IsMuted = false;
   private ARCConfigured = true;
@@ -154,7 +154,7 @@ export class AnthemZone{
   private PowerConfigured = false;
   private VolumePercentage = 0;
   private Volume = 0;
-  private AudioListenningMode = AnthemAudioListenningMode.NONE;
+  private AudioListeningMode = AnthemAudioListeningMode.NONE;
   ZoneName = '';
 
   constructor(ZoneNumber: number, ZoneName: string, IsMainZone: boolean) {
@@ -228,12 +228,12 @@ export class AnthemZone{
     return this.PowerConfigured;
   }
 
-  SetALM(AudioListenningMode:number){
-    this.AudioListenningMode = AudioListenningMode;
+  SetALM(AudioListeningMode:number){
+    this.AudioListeningMode = AudioListeningMode;
   }
 
   GetALM():number{
-    return this.AudioListenningMode;
+    return this.AudioListeningMode;
   }
 }
 
@@ -1175,10 +1175,9 @@ export class AnthemController extends TypedEmitter<AnthemControllerEvent> {
             for(let i = 0 ; i < Response.length-2; i++){
               if(TempString.substring(i, i+2) === 'IN'){
                 const InputNumber = Number(TempString.substring(0, i));
-                const Name = TempString.substring(i+2, TempString.length);
-
+                let Name = TempString.substring(i+2, TempString.length);
+                Name = this.ReceiverModel == AnthemReceiverModel.MRXSLM ? Buffer.from(Name, 'hex').toString() : Name;
                 this.InputNameArray[InputNumber-1] = Name;
-
                 if(this.CurrentState === ControllerState.Operation){
                   if(InputNumber === this.InputNameArray.length){
                     if(this.GetInputHasChange()){

--- a/src/HKALMAccessoryNG.ts
+++ b/src/HKALMAccessoryNG.ts
@@ -13,7 +13,7 @@ export class HKALMAccessoryNG extends HKAccessory {
       Controller,
       'Zone' + ZoneNumber + ' ALM', // Name
       Controller.SerialNumber + ZoneNumber + 'ALM NG'); // UUID
-    this.platform.log.info('Zone' + ZoneNumber + ': Audio Listenning Mode');
+    this.platform.log.info('Zone' + ZoneNumber + ': Audio Listening Mode');
 
     // set accessory information
     this.Accessory.getService(this.platform.Service.AccessoryInformation)!

--- a/src/HKBrightnessAccessory.ts
+++ b/src/HKBrightnessAccessory.ts
@@ -38,7 +38,7 @@ export class HKBrightnessAccessory extends HKAccessory {
 
     this.Controller.on('ZonePowerChange', ( ) => {
       // Power off panel accessory if all zone are off
-      if(!this.Controller.GetZonePower(1) && !this.Controller.GetZonePower(2)){
+      if(this.AllZonesOff()){
         this.PanelBrightnessOn = false;
         this.service.getCharacteristic(this.platform.Characteristic.On).updateValue(false);
         this.service.getCharacteristic(this.platform.Characteristic.Brightness).updateValue(false);
@@ -48,8 +48,8 @@ export class HKBrightnessAccessory extends HKAccessory {
 
   SetPanelBrightness(value){
 
-    // If Zone1 and Zone2 are powered off, cannot change brightness level
-    if(!this.Controller.GetZonePower(1) && !this.Controller.GetZonePower(2)){
+    // If configured zones are powered off, cannot change brightness level
+    if(this.AllZonesOff()){
       this.platform.log.error('Brightness Accessory' +': Cannot change brightness level, zone are not powered on');
       setTimeout(() => {
         this.service.getCharacteristic(this.platform.Characteristic.On).updateValue(false);
@@ -61,12 +61,17 @@ export class HKBrightnessAccessory extends HKAccessory {
     this.Controller.SetPanelBrightness(value);
   }
 
+  AllZonesOff(){
+    this.platform.log.info('zones length: ', this.Controller.GetConfiguredZoneNumber());
+    return this.Controller.GetConfiguredZoneNumber() > 1 ? !this.Controller.GetZonePower(1) && !this.Controller.GetZonePower(2) : !this.Controller.GetZonePower(1);
+  }
+
   SetPanelOn(value){
 
     this.PanelBrightnessOn = value;
 
-    // If Zone1 and Zone2 are powered off, cannot change accessory stage
-    if(!this.Controller.GetZonePower(1) && !this.Controller.GetZonePower(2)){
+    // If configured zones are powered off, cannot change accessory stage
+    if(this.AllZonesOff()){
       this.platform.log.error('Brightness Accessory' +': Cannot change status, zone are not powered on');
       setTimeout(() => {
         this.service.getCharacteristic(this.platform.Characteristic.On).updateValue(false);

--- a/src/HKBrightnessAccessory.ts
+++ b/src/HKBrightnessAccessory.ts
@@ -62,8 +62,8 @@ export class HKBrightnessAccessory extends HKAccessory {
   }
 
   AllZonesOff(){
-    this.platform.log.info('zones length: ', this.Controller.GetConfiguredZoneNumber());
-    return this.Controller.GetConfiguredZoneNumber() > 1 ? !this.Controller.GetZonePower(1) && !this.Controller.GetZonePower(2) : !this.Controller.GetZonePower(1);
+    let isSLM = this.Controller.ReceiverModel == 'MRX SLM';
+    return isSLM ? !this.Controller.GetZonePower(1) && !this.Controller.GetZonePower(2) : !this.Controller.GetZonePower(1);
   }
 
   SetPanelOn(value){

--- a/src/HKBrightnessAccessory.ts
+++ b/src/HKBrightnessAccessory.ts
@@ -63,7 +63,7 @@ export class HKBrightnessAccessory extends HKAccessory {
 
   AllZonesOff(){
     let isSLM = this.Controller.ReceiverModel == 'MRX SLM';
-    return isSLM ? !this.Controller.GetZonePower(1) && !this.Controller.GetZonePower(2) : !this.Controller.GetZonePower(1);
+    return !isSLM ? !this.Controller.GetZonePower(1) && !this.Controller.GetZonePower(2) : !this.Controller.GetZonePower(1);
   }
 
   SetPanelOn(value){

--- a/src/HKPowerInputAccessory.ts
+++ b/src/HKPowerInputAccessory.ts
@@ -70,9 +70,10 @@ export class HKPowerInputAccessory {
 
     for (let i = 0; i < InputArray.length ; i++){
       const hdmiInputService = this.ReceiverAccessory.addService(this.platform.Service.InputSource, 'hdmi'+(i+1), 'HDMI '+ (i+1));
+      let ConfiguredName = this.Controller.ReceiverModel == 'MRX SLM'? Buffer.from(InputArray[i], 'hex').toString() : InputArray[i];
       hdmiInputService
         .setCharacteristic(this.platform.Characteristic.Identifier, (i+1))
-        .setCharacteristic(this.platform.Characteristic.ConfiguredName, InputArray[i])
+        .setCharacteristic(this.platform.Characteristic.ConfiguredName, ConfiguredName)
         .setCharacteristic(this.platform.Characteristic.IsConfigured, this.platform.Characteristic.IsConfigured.CONFIGURED)
         .setCharacteristic(this.platform.Characteristic.InputSourceType, this.platform.Characteristic.InputSourceType.HDMI);
       this.TVService.addLinkedService(hdmiInputService);

--- a/src/HKPowerInputAccessory.ts
+++ b/src/HKPowerInputAccessory.ts
@@ -70,10 +70,9 @@ export class HKPowerInputAccessory {
 
     for (let i = 0; i < InputArray.length ; i++){
       const hdmiInputService = this.ReceiverAccessory.addService(this.platform.Service.InputSource, 'hdmi'+(i+1), 'HDMI '+ (i+1));
-      let ConfiguredName = this.Controller.ReceiverModel == 'MRX SLM'? Buffer.from(InputArray[i], 'hex').toString() : InputArray[i];
       hdmiInputService
         .setCharacteristic(this.platform.Characteristic.Identifier, (i+1))
-        .setCharacteristic(this.platform.Characteristic.ConfiguredName, ConfiguredName)
+        .setCharacteristic(this.platform.Characteristic.ConfiguredName, InputArray[i])
         .setCharacteristic(this.platform.Characteristic.IsConfigured, this.platform.Characteristic.IsConfigured.CONFIGURED)
         .setCharacteristic(this.platform.Characteristic.InputSourceType, this.platform.Characteristic.InputSourceType.HDMI);
       this.TVService.addLinkedService(hdmiInputService);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -56,7 +56,7 @@ export class AnthemReceiverHomebridgePlatform implements DynamicPlatformPlugin {
 
     this.api.on('didFinishLaunching', () => {
       log.debug('Finished initializing platform');
-      let isSLM = this.Controller.ReceiverModel == 'MRX SLM';
+
       // Do not start plugin if errors has been found in config file
       if(this.CheckConfigFile()){
 
@@ -64,7 +64,7 @@ export class AnthemReceiverHomebridgePlatform implements DynamicPlatformPlugin {
           this.log.error('Error adding zone 1 to controller');
         }
         
-        if (!isSLM){ // SLM only has one zone
+        if (this.Controller.GetConfiguredZoneNumber() > 1){ // SLM only has one zone
           if(!this.Controller.AddControllingZone(2, this.Zone2Name, false)){
             this.log.error('Error adding zone 2 to controller');
           }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -63,11 +63,12 @@ export class AnthemReceiverHomebridgePlatform implements DynamicPlatformPlugin {
         if(!this.Controller.AddControllingZone(1, this.Zone1Name, true)){
           this.log.error('Error adding zone 1 to controller');
         }
-
-        if(!this.Controller.AddControllingZone(2, this.Zone2Name, false)){
-          this.log.error('Error adding zone 2 to controller');
+        
+        if (this.Controller.GetConfiguredZoneNumber() > 1){ // SLM only has one zone
+          if(!this.Controller.AddControllingZone(2, this.Zone2Name, false)){
+            this.log.error('Error adding zone 2 to controller');
+          }
         }
-
         // Start operation when controller is ready
         this.Controller.on('ControllerReadyForOperation', () => {
           this.DumpControllerInfo();

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -126,7 +126,7 @@ export class AnthemReceiverHomebridgePlatform implements DynamicPlatformPlugin {
   discoverDevices() {
 
     this.log.info('-----------------------------------------');
-    this.log.info('Configuring Hombebridge Accessories');
+    this.log.info('Configuring Homebridge Accessories');
     this.log.info('-----------------------------------------');
 
     const Inputs = this.Controller.GetInputs();
@@ -134,7 +134,6 @@ export class AnthemReceiverHomebridgePlatform implements DynamicPlatformPlugin {
     if(this.PanelBrightness){
       this.AddBrightnessAccessory();
     }
-
     if(this.Zone1Active){
       const AnthemReceiver = new HKPowerInputAccessory(this, this.Controller, 1);
       this.AnthemReceiverPowerInputArray.push(AnthemReceiver);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -56,7 +56,7 @@ export class AnthemReceiverHomebridgePlatform implements DynamicPlatformPlugin {
 
     this.api.on('didFinishLaunching', () => {
       log.debug('Finished initializing platform');
-
+      let isSLM = this.Controller.ReceiverModel == 'MRX SLM';
       // Do not start plugin if errors has been found in config file
       if(this.CheckConfigFile()){
 
@@ -64,7 +64,7 @@ export class AnthemReceiverHomebridgePlatform implements DynamicPlatformPlugin {
           this.log.error('Error adding zone 1 to controller');
         }
         
-        if (this.Controller.GetConfiguredZoneNumber() > 1){ // SLM only has one zone
+        if (!isSLM){ // SLM only has one zone
           if(!this.Controller.AddControllingZone(2, this.Zone2Name, false)){
             this.log.error('Error adding zone 2 to controller');
           }


### PR DESCRIPTION
The MLX SLM released in 2025 has a few nuances that set it apart from other models.

- GCLEDB replaces GCFPB as it only has an LED not a Front Panel. 
- LED has four brightness settings (0,40,80,100) so this handles input, rounds and sets to 0,33,66,100 brightness.
- Only one Zone is supported, so Zone 2 setup now checks for active zones
- Input names from MRX SLM come in as hex, which requires conversion. Not sure if this was not needed in other models. So only converting MRX input names.

Everything appears to be working as expected with these updates, without breaking changes.